### PR TITLE
#50 split json in definition and main object

### DIFF
--- a/lib/parsers/root_parser.ex
+++ b/lib/parsers/root_parser.ex
@@ -23,8 +23,11 @@ defmodule JS2E.Parsers.RootParser do
         title = Map.get(root_node, "title", "")
         description = Map.get(root_node, "description")
 
-        definitions_parser_result = parse_definitions(root_node, schema_id)
-        root_parser_result = parse_root_object(root_node, schema_id, title)
+        root_node_no_def = Map.delete(root_node, "definitions")
+        root_node_only_def = Map.take(root_node, ["$schema", "id", "title", "definitions"])
+
+        definitions_parser_result = parse_definitions(root_node_only_def, schema_id)
+        root_parser_result = parse_root_object(root_node_no_def, schema_id, title)
 
         %ParserResult{type_dict: type_dict,
                       errors: errors,


### PR DESCRIPTION
Maybe it is not the best solution but giving to `parse_definitions` and `parse_root_object` only the pieces of json schema they need seems to fix the problem.

It works both with the small example of #50 and with my complex schema (~1500 lines of generated `elm` code).

Clearly comments are welcome, I don't know if I'm missing some case or breaking something else. If you think this solution is acceptable I can add some tests.